### PR TITLE
Force -fopenmp when using hipcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ foreach(i ${rochpl_device_source})
 endforeach()
 
 # HIP flags workaround while target_compile_options does not work
-list(APPEND HIP_HIPCC_FLAGS "-Wno-unused-command-line-argument -fPIE")
+list(APPEND HIP_HIPCC_FLAGS "-Wno-unused-command-line-argument -fPIE -fopenmp")
 list(APPEND CMAKE_HOST_FLAGS "")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
Older versions of hipcc/clang (erroneously, I think) would find omp.h without specifying the -fopenmp compiler flag nor an appropriate include path. Newer versions of hipcc coming in ROCm 6 will change this behavior and we can no longer compiler HIP files that either explicitly or implicitly include omp.h. So we add -fopenmp to HIPCC flags.

Updating the FindOpenMP behavior or depending on that is probably a better solution, but this is at least an easy fix to start from.